### PR TITLE
Refactors Quotes object into a map

### DIFF
--- a/models/quote.go
+++ b/models/quote.go
@@ -10,7 +10,7 @@ const (
 	ErrTplNotSupported = "source '%s' does not support action '%s'"
 )
 
-type Quotes []*Quote
+type Quotes map[string]*Quote
 
 type Quote struct {
 	Symbol   string /* e.g.: VEUR.AS, Vanguard dev. europe on Amsterdam */

--- a/sources/bloomberg/bloomberg.go
+++ b/sources/bloomberg/bloomberg.go
@@ -20,7 +20,7 @@ func New() gofinance.Source {
 func (s *BloombergSource) Quote(symbols []string) (models.Quotes, error) {
 	symbols = convertSymbols(symbols)
 
-	slice := make(models.Quotes, 0, len(symbols))
+	quotes := make(models.Quotes)
 
 	results := make(chan *models.Quote, len(symbols))
 	errors := make(chan error, len(symbols))
@@ -43,11 +43,11 @@ func (s *BloombergSource) Quote(symbols []string) (models.Quotes, error) {
 			fmt.Println("bloomberg: error while fetching,", err)
 		case r := <-results:
 			r.Symbol = bloombergToYahoo(r.Symbol)
-			slice = append(slice, r)
+			quotes[r.Symbol] = r
 		}
 	}
 
-	return slice, nil
+	return quotes, nil
 }
 
 func (s *BloombergSource) Hist(symbols []string) (models.HistMap, error) {

--- a/sources/yahoofinance/csv.go
+++ b/sources/yahoofinance/csv.go
@@ -37,7 +37,7 @@ func csvQuotes(symbols []string) (models.Quotes, error) {
 	defer req.Close()
 	r := csv.NewReader(req)
 
-	results := make(models.Quotes, 0, len(symbols))
+	quotes := make(models.Quotes)
 	for {
 		fields, err := r.Read()
 		if err == io.EOF {
@@ -69,10 +69,10 @@ func csvQuotes(symbols []string) (models.Quotes, error) {
 			res.DividendExDate = tm
 		}
 
-		results = append(results, &res)
+		quotes[res.Symbol] = &res
 	}
 
-	return results, nil
+	return quotes, nil
 }
 
 func floatOr(orig string) float64 {

--- a/sources/yahoofinance/yql.go
+++ b/sources/yahoofinance/yql.go
@@ -185,7 +185,7 @@ func yqlQuotes(symbols []string) (models.Quotes, error) {
 		quotes = resp.Query.Results.Quote
 	}
 
-	results := make(models.Quotes, 0, len(quotes))
+	results := make(models.Quotes)
 	for _, rawres := range quotes {
 		rawres.Process()
 
@@ -214,7 +214,7 @@ func yqlQuotes(symbols []string) (models.Quotes, error) {
 		if rawres.ExDividendDate != nil {
 			res.DividendExDate = rawres.ExDividendDate.GetTime()
 		}
-		results = append(results, &res)
+		results[res.Symbol] = &res
 	}
 
 	return results, nil


### PR DESCRIPTION
I think using a map instead of a slice makes more sense for storing and accessing quotes